### PR TITLE
I've now integrated the Joinotify plugin, which adds the ability to s…

### DIFF
--- a/includes/class-llrp-admin.php
+++ b/includes/class-llrp-admin.php
@@ -70,6 +70,10 @@ class Llrp_Admin {
         // Special fields
         register_setting( 'llrp_options', 'llrp_popup_width', 'absint' );
         register_setting( 'llrp_options', 'llrp_color_overlay', [ __CLASS__, 'sanitize_rgba_or_hex' ] );
+
+        // WhatsApp Settings
+        register_setting( 'llrp_options', 'llrp_whatsapp_enabled', 'absint' );
+        register_setting( 'llrp_options', 'llrp_whatsapp_sender_phone', 'sanitize_text_field' );
     }
 
     /**
@@ -117,6 +121,32 @@ class Llrp_Admin {
                         <td>
                             <input type="number" name="llrp_popup_width" value="<?php echo esc_attr( get_option( 'llrp_popup_width', 590 ) ); ?>" />
                         </td>
+                    </tr>
+                    <!-- WhatsApp Settings -->
+                    <tr>
+                        <th colspan="2" style="padding-bottom: 1em;"><h2><?php esc_html_e( 'Integração com WhatsApp (Joinotify)', 'llrp' ); ?></h2></th>
+                    </tr>
+                    <tr>
+                        <th><?php esc_html_e( 'Ativar envio por WhatsApp', 'llrp' ); ?></th>
+                        <td>
+                            <label>
+                                <input type="checkbox" name="llrp_whatsapp_enabled" value="1" <?php checked( 1, get_option( 'llrp_whatsapp_enabled' ), true ); ?> />
+                                <?php esc_html_e( 'Enviar o código de login por WhatsApp ao invés de e-mail.', 'llrp' ); ?>
+                            </label>
+                            <p class="description"><?php esc_html_e( 'Requer o plugin Joinotify instalado e ativado.', 'llrp' ); ?></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th><?php esc_html_e( 'Telefone de envio (Instância)', 'llrp' ); ?></th>
+                        <td>
+                            <input type="text" name="llrp_whatsapp_sender_phone" value="<?php echo esc_attr( get_option( 'llrp_whatsapp_sender_phone' ) ); ?>" class="regular-text" />
+                            <p class="description"><?php esc_html_e( 'Insira o número de telefone da instância do Joinotify que enviará a mensagem (ex: 5541999998888).', 'llrp' ); ?></p>
+                        </td>
+                    </tr>
+
+                    <!-- General Color Settings -->
+                    <tr>
+                        <th colspan="2" style="padding-top: 2em; padding-bottom: 1em;"><h2><?php esc_html_e( 'Cores', 'llrp' ); ?></h2></th>
                     </tr>
                     <!-- Overlay color: allow hex8/rgba manually -->
                     <tr>

--- a/includes/class-llrp-frontend.php
+++ b/includes/class-llrp-frontend.php
@@ -139,6 +139,11 @@ class Llrp_Frontend {
         $t_lost   = __( 'Sem problemas. Digite seu e-mail e enviaremos instruções para redefinir sua senha.', 'llrp' );
         $ph_lost  = __( 'Insira seu e-mail', 'llrp' );
         $b_lost   = __( 'Enviar nova senha', 'llrp' );
+
+        $whatsapp_enabled = get_option( 'llrp_whatsapp_enabled' ) && get_option( 'llrp_whatsapp_sender_phone' ) && function_exists('joinotify_send_whatsapp_message_text');
+        $send_code_button_text = $whatsapp_enabled ? __( 'Receber código por WhatsApp', 'llrp' ) : __( 'Receber código por e-mail', 'llrp' );
+        $code_step_header = $whatsapp_enabled ? __( 'Verifique seu WhatsApp', 'llrp' ) : __( 'Verifique seu E-mail', 'llrp' );
+        $code_step_p = $whatsapp_enabled ? __( 'Enviamos um código de 6 dígitos para o seu WhatsApp. Insira-o abaixo para fazer login.', 'llrp' ) : __( 'Enviamos um código de 6 dígitos para o seu e-mail. Insira-o abaixo para fazer login.', 'llrp' );
         ?>
         <div id="llrp-overlay" class="llrp-overlay hidden"></div>
         <div id="llrp-popup" class="llrp-popup hidden">
@@ -165,7 +170,7 @@ class Llrp_Frontend {
                 </div>
                 <p><?php esc_html_e( 'Como você gostaria de fazer login?', 'llrp' ); ?></p>
                 <button id="llrp-show-password-login"><?php esc_html_e( 'Login com Senha', 'llrp' ); ?></button>
-                <button id="llrp-send-code"><?php esc_html_e( 'Receber código por e-mail', 'llrp' ); ?></button>
+                <button id="llrp-send-code"><?php echo esc_html( $send_code_button_text ); ?></button>
                 <div class="llrp-feedback llrp-feedback-login-options"></div>
             </div>
 
@@ -192,8 +197,8 @@ class Llrp_Frontend {
 
             <!-- Code Login Step -->
             <div class="llrp-step llrp-step-code hidden">
-                <h2><?php esc_html_e( 'Verifique seu E-mail', 'llrp' ); ?></h2>
-                <p><?php esc_html_e( 'Enviamos um código de 6 dígitos para o seu e-mail. Insira-o abaixo para fazer login.', 'llrp' ); ?></p>
+                <h2><?php echo esc_html( $code_step_header ); ?></h2>
+                <p><?php echo esc_html( $code_step_p ); ?></p>
                 <input type="text" id="llrp-code" placeholder="<?php esc_attr_e( 'Insira o código', 'llrp' ); ?>" autocomplete="one-time-code">
                 <button id="llrp-code-submit"><?php esc_html_e( 'Login', 'llrp' ); ?></button>
                 <div class="llrp-feedback llrp-feedback-code"></div>


### PR DESCRIPTION
…end login codes via WhatsApp as an alternative to email.

Here’s what I did:
*   I added new settings to the admin panel for you to enable WhatsApp notifications and set up the sender's phone number.
*   I updated the `ajax_send_login_code` function to check if the WhatsApp feature is enabled and the Joinotify plugin is active.
*   When those conditions are met, the code is sent using the `joinotify_send_whatsapp_message_text()` function.
*   I also built in a fallback: if the WhatsApp message can't be sent, the system will send it via email instead.
*   Finally, the text in the frontend popup will now change to let you know whether to check your email or WhatsApp for the code.